### PR TITLE
Sort datapoints from cloudwatch to make sure we always use the latest result

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/cloudwatch.py
+++ b/zmon_worker_monitor/builtins/plugins/cloudwatch.py
@@ -74,7 +74,7 @@ class CloudwatchWrapper(object):
                 continue
             response = self.client.get_metric_statistics(Namespace=metric['Namespace'], MetricName=metric['MetricName'], Dimensions=metric['Dimensions'],
                                                          StartTime=start, EndTime=end, Period=period, Statistics=[statistics])
-            data_points = response['Datapoints']
+            data_points = sorted(response['Datapoints'], key=lambda x: x["Timestamp"])
             if data_points:
                 data[metric['MetricName']] += data_points[-1][statistics]
         return data


### PR DESCRIPTION
From experimenting I saw that the list in the response is not sorted, so that a random data point would be chosen.