### PR TITLE
Changing the config keys in the code, adding comment in the plugin co…

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/scalyr.py
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.py
@@ -15,7 +15,7 @@ class ScalyrWrapperFactory(IFunctionFactoryPlugin):
         super(ScalyrWrapperFactory, self).__init__()
 
     def configure(self, conf):
-        self.read_key = conf.get('read.key', '')
+        self.read_key = conf.get('scalyr.read.key', '')
         return
 
     def create(self, factory_ctx):
@@ -115,5 +115,5 @@ class ScalyrWrapper(object):
 if __name__ == '__main__':
     import os
 
-    s = ScalyrWrapper(read_key=os.getenv('SCALYR_READ_KEY'))
+    s = ScalyrWrapper(read_key=os.getenv('WORKER_SCALYR_READ_KEY'))
     print s.count(query="$application_id='zmon-scheduler'")

--- a/zmon_worker_monitor/builtins/plugins/scalyr.worker_plugin
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.worker_plugin
@@ -9,3 +9,9 @@ Website = https://github.com/zalando/zmon-worker
 Description = Builtin plugin that provides an Scalyr functions
 
 [Configuration]
+;; The configuration section is optional, you can put here any parameters needed to configure the plugin.
+;; Note that these values may are overridden by zmon's global config.
+;; key = valueX
+;; Note valueX will be overridden if Zmon's global config has: plugin.{plugin_name}.{key} = valueY
+
+;; scalyr.read.key


### PR DESCRIPTION
1. Updated the configuration keys for read key of the scalyr in scalyr plugin.
2. The token should now be read as configuration by setting environment variable **WORKER_SCALYR_READ_KEY.**
3. Added a comment in the plugin definition of scalyr could serve as documentation.