### PR TITLE
wrong keyword for scan function

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -72,8 +72,8 @@ class RedisWrapper(object):
     def hgetall(self, key):
         return self.__con.hgetall(key)
 
-    def scan(self, cursor, pattern=None, count=None):
-        return self.__con.scan(cursor, pattern=pattern, count=count)
+    def scan(self, cursor, match=None, count=None):
+        return self.__con.scan(cursor, match=match, count=count)
 
     def statistics(self):
         '''


### PR DESCRIPTION
introduced in https://github.com/zalando/zmon-worker/pull/41 , but i used the wrong keyword (see http://redis.io/commands/scan) ... the docs are still correct ...