### PR TITLE
make requests library use the Debian CA bundle (includes Zalando CA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM registry.opensource.zalan.do/stups/ubuntu:16.04-29
 RUN apt-get update && apt-get -y install python-pip python-dev libev4 libev-dev python-psycopg2 libpq-dev libldap2-dev libsasl2-dev libssl-dev libsnappy-dev && \
     pip2 install -U pip setuptools urllib3
 
+# make requests library use the Debian CA bundle (includes Zalando CA)
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 ADD requirements.txt /app/requirements.txt
 RUN pip2 install -r /app/requirements.txt
 


### PR DESCRIPTION
See https://github.com/zalando/docker-python/blob/master/Dockerfile#L16 (we cannot use the Python base image as we still need to use Python 2.7 for ZMON Worker)