### PR TITLE
Add support for configured Elasticsearch URL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,6 @@ plugin.mysql.pass: '--secret--'
 
 plugin.mssql.user: 'zmon'
 plugin.mssql.pass: '--secret--'
+
+plugin.elasticsearch.url: 'https://es-cluster'
+# plugin.elasticsearch.oauth2_scopes: read

--- a/tests/config-test.yaml
+++ b/tests/config-test.yaml
@@ -44,3 +44,6 @@ plugin.mysql.pass: '--secret--'
 
 plugin.mssql.user: 'zmon'
 plugin.mssql.pass: '--secret--'
+
+plugin.elasticsearch.url: 'https://es-cluster'
+# plugin.elasticsearch.oauth2_scopes: read

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -258,3 +258,8 @@ def test_elasticsearch_search_error(monkeypatch):
         es.search()
 
         assert ex is not HttpError
+
+
+def test_elasticsearch_no_url():
+    with pytest.raises(RuntimeError):
+        ElasticsearchWrapper()

--- a/zmon_worker_monitor/builtins/plugins/elasticsearch.py
+++ b/zmon_worker_monitor/builtins/plugins/elasticsearch.py
@@ -48,7 +48,12 @@ class ElasticsearchFactory(IFunctionFactoryPlugin):
         :param factory_ctx: (dict) names available for Function instantiation
         :return: an object that implements a check function
         """
-        return propartial(ElasticsearchWrapper, url=self._url)
+        url = factory_ctx.get('entity_url')
+
+        if not url and self._url:
+            url = self._url
+
+        return propartial(ElasticsearchWrapper, url=url)
 
 
 class ElasticsearchWrapper(object):

--- a/zmon_worker_monitor/builtins/plugins/elasticsearch.py
+++ b/zmon_worker_monitor/builtins/plugins/elasticsearch.py
@@ -33,12 +33,14 @@ class ElasticsearchFactory(IFunctionFactoryPlugin):
     def __init__(self):
         super(ElasticsearchFactory, self).__init__()
 
+        self._url = None
+
     def configure(self, conf):
         """
         Called after plugin is loaded to pass the [configuration] section in their plugin info file
         :param conf: configuration dictionary
         """
-        return
+        self._url = conf.get('url')
 
     def create(self, factory_ctx):
         """
@@ -46,11 +48,14 @@ class ElasticsearchFactory(IFunctionFactoryPlugin):
         :param factory_ctx: (dict) names available for Function instantiation
         :return: an object that implements a check function
         """
-        return propartial(ElasticsearchWrapper)
+        return propartial(ElasticsearchWrapper, url=self._url)
 
 
 class ElasticsearchWrapper(object):
-    def __init__(self, url, timeout=10, oauth2=False):
+    def __init__(self, url=None, timeout=10, oauth2=False):
+        if not url:
+            raise RuntimeError('Elasticsearch plugin improperly configured. URL is required!')
+
         self.url = url
         self.timeout = timeout
         self.oauth2 = oauth2

--- a/zmon_worker_monitor/builtins/plugins/elasticsearch.worker_plugin
+++ b/zmon_worker_monitor/builtins/plugins/elasticsearch.worker_plugin
@@ -9,3 +9,5 @@ Website = https://github.com/zalando/zmon-worker
 Description = Builtin plugin that provides Elasticsearch query capabilities
 
 [Configuration]
+
+url = https://es-cluster/


### PR DESCRIPTION
+ URL can be overridden in check-command to query external ES cluster